### PR TITLE
Resolvendo erro de linter

### DIFF
--- a/status/error.go
+++ b/status/error.go
@@ -3,19 +3,19 @@ package status
 import "fmt"
 
 // StatusError wraps a code and a error messager
-type StatusError struct {
+type Error struct {
 	Err  error
 	Code Code
 }
 
-// NewStatusError creates a new StatusError
-func NewStatusError(code Code, error error) error {
-	return &StatusError{
+// NewError creates a new StatusError
+func NewError(code Code, error error) error {
+	return &Error{
 		Err:  error,
 		Code: code,
 	}
 }
 
-func (se *StatusError) Error() string {
+func (se *Error) Error() string {
 	return fmt.Sprintf("error %v , %v", se.Code, se.Err.Error())
 }

--- a/status/status.go
+++ b/status/status.go
@@ -55,7 +55,7 @@ func Text(code Code) string {
 // passing the code if err is of type StatusError
 func ExitFromError(err error) {
 	log.Println(fmt.Errorf("%q", err))
-	var se *StatusError
+	var se *Error
 	if errors.As(err, &se) {
 		os.Exit(int(se.Code))
 	}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -38,7 +38,7 @@ func TestText(t *testing.T) {
 func TestExitFromError(t *testing.T) {
 	testCode := int(InvalidFile)
 	if os.Getenv("FLAG") == "1" {
-		ExitFromError(NewStatusError(InvalidFile, errors.New("Invalid Parameters")))
+		ExitFromError(NewError(InvalidFile, errors.New("Invalid Parameters")))
 		return
 	}
 	cmd := exec.Command(os.Args[0], "-test.run=TestExitFromError")


### PR DESCRIPTION
> status/status_error.go:6:6: type name **will be used as status.StatusError by other packages and that stutters; consider calling this Error'