### PR TITLE
Registros atualizados para o pipeline

### DIFF
--- a/mprj/src/parser.py
+++ b/mprj/src/parser.py
@@ -147,8 +147,11 @@ def parse_employees(file_name):
         ceil_ret = float(row[15]) #Retenção por teto constitucional
         income_tax = float(row[14]) #Imposto de renda
 
+        #Importante devido  a natureza das formas de registro o orgão já reportadas o registro ou matrícula
+        #para fins de comparação e de chave deve ser visto como um number(Float). entretanto para fins de armazenamento
+        #deve-se considera-lo como uma string, de modo a manter a coerência com nosso pipeline.
         employees[reg] = {
-            'reg': reg,
+            'reg': str(row[0]),
             'name': row[1],
             'type': typeE,
             'active': activeE,

--- a/mprj/src/parser_test.py
+++ b/mprj/src/parser_test.py
@@ -10,7 +10,7 @@ class TestParser(unittest.TestCase):
         self.maxDiff = None
 
         expected = {
-            'reg': 02003042.0 ,
+            'reg': '02003042' ,
             'name': 'ADELIA BARBOZA DE CARVALHO',
             'role': 'PROCURADOR DE JUSTICA',
             'type': 'membro',
@@ -66,7 +66,7 @@ class TestParser(unittest.TestCase):
         self.maxDiff = None
 
         expected = {
-            'reg': 00179515.0,
+            'reg': '00179515',
             'name': 'ADA BUKSMAN',
             'role': 'PROMOTOR DE JUSTICA',
             'type': 'membro',
@@ -115,7 +115,7 @@ class TestParser(unittest.TestCase):
         self.maxDiff = None
 
         expected = {
-            'reg': 00003189.0,
+            'reg': '00003189',
             'name': 'ACELINO AMURIM DA SILVA',
             'role': 'TÉCNICO DO MP - ÁREA: PROCESSUAL',
             'type': 'servidor',
@@ -171,7 +171,7 @@ class TestParser(unittest.TestCase):
         self.maxDiff = None
 
         expected = {
-            'reg': 00001322.0,
+            'reg': '00001322',
             'name': 'ADELAIDE BURATTO',
             'role': 'AUXILIAR DO MP - ÁREA: ADMINISTRATIVA',
             'type': 'servidor',
@@ -290,7 +290,7 @@ class TestParser(unittest.TestCase):
         self.maxDiff = None
 
         expected = {
-            'reg': 00004938.0,
+            'reg':'00004938',
             'name': 'ZILMA OLIVEIRA MARQUES',
             'role': 'TÉCNICO DO MP - ÁREA: ADMINISTRATIVA',
             'type': 'servidor',
@@ -345,7 +345,7 @@ class TestParser(unittest.TestCase):
         self.maxDiff = None
 
         expected = {
-            'reg': 00198219.0,
+            'reg': '00198219',
             'name': 'ANA CHRISTINA ARAGÃO COSTA',
             'role': 'ANALISTA DO MP - ÁREA: ADMINISTRATIVA',
             'type': 'servidor',


### PR DESCRIPTION
- Rodando o alba notei conflito com a situação dos registros de um mesmo funcionário ter 2 formas.
- Não era padrão retornar float como reg para o pipeline.
- Como as situações onde entender como o float é util apenas para questões de comparação, simplesmente usamos float  para comparar e string para imprimir.
- Deixou os testes bem mais coerentes com a planilha original.
- No caso de aprovação deste PR, já posso libertar dados referentes ao mprj. 