### PR TITLE
Ajustando situação de remuneração bruta doscolaboradores

### DIFF
--- a/mprj/src/parser.py
+++ b/mprj/src/parser.py
@@ -219,6 +219,7 @@ def parse_colab(file_name):
             curr_row += 1
             continue
 
+        wage = float(row[2]) #Valor bruto recebido pelo colaborador
         #O identificador de colaboradores é o nome
         employees[row[1]] = {
             'name': row[1],
@@ -229,7 +230,8 @@ def parse_colab(file_name):
             'active': activeE,
             "income":
             {
-                'total': float(row[2]),
+                'total': wage,
+                'wage': wage,
             },
             'discounts':
             {

--- a/mprj/src/parser_test.py
+++ b/mprj/src/parser_test.py
@@ -271,6 +271,7 @@ class TestParser(unittest.TestCase):
             'income':
             {
                 'total': 870.00,
+                'wage': 870.00,
             },
             'discounts':
             {


### PR DESCRIPTION
- Faltava o campo income.wage em colaboradores. 
- A planilha só identificava o valor bruto em montante que setei como total.
-Agora colaboradores contém o valor bruto recebido no campo wage .