### PR TITLE
CNJ - Corrige (novamente) o Dockerfile

### DIFF
--- a/cnj/Dockerfile
+++ b/cnj/Dockerfile
@@ -4,7 +4,7 @@ FROM alpine:latest
 ARG COURT
 ARG YEAR
 ARG MONTH
-ENV FILE = ${COURT}-${MONTH}-${YEAR}.json
+ENV FILE=${COURT}-${MONTH}-${YEAR}.json
 
 # copy the file to the working directory
 ADD https://github.com/diegooalmeida/backup/raw/master/${COURT}.zip .


### PR DESCRIPTION
A sintaxe padrão pro comando ENV em dockerfiles é a seguinte (sem espaços): 
ENV MY_NAME="John Doe"

Mas ela permite uma sintaxe alternativa (sem o "=", separando por espaço):
ENV MY_NAME "John Doe"

Da forma que estava o Dockerfile do CNJ, (com espaço antes do sinal de igualdade, a sintaxe alternativa que estava sendo utilizada, e o sinal de igualdade estava sendo incluído no valor da variavel, acarretando o seguinte erro: 
cat: can't open '=': no such file or directory
