### PR TITLE
CNJ - Correção no Parser

### DIFF
--- a/cnj/src/parser.py
+++ b/cnj/src/parser.py
@@ -337,7 +337,7 @@ def save_file(court, month, year, output_path, crawler_version, employees):
             'id': court.lower(),
             'version': crawler_version,
         },
-        'employees': employees,
+        'employees': list(employees.values()),
         # https://hackernoon.com/today-i-learned-dealing-with-json-datetime-when-unmarshal-in-golang-4b281444fb67
         'timestamp': now.astimezone().replace(microsecond=0).isoformat(),
     }


### PR DESCRIPTION
Corrige a estrutura dos employees a ser utilizada no Crawling Result. Antes era passado todo o dicionário (chaves e valores). Agora, apenas uma lista contendo os valores, sem as chaves, que é o padrão utilizado no projeto, e provavelmente o que o alba espera receber.