### PR TITLE
Ajustando remoção de NAN values do dataframe, (alguns passavam)

### DIFF
--- a/mpes/src/parser.py
+++ b/mpes/src/parser.py
@@ -22,8 +22,7 @@ def employees_parser(file_path):
 
     #Ajustando dataframe para simplificar interação
     data = data[data['Unnamed: 0'].notna()]
-    data = data[:-1]
-    data = data[1:]
+    data = data.dropna()
     clean_currency(data,4,14)
 
     #Parsing data
@@ -139,8 +138,7 @@ def employees_parser_befago(file_path):
     
     #Ajustando dataframe 
     data = data[data['Unnamed: 0'].notna()]
-    data = data[:-1]
-    data = data[1:]
+    data = data.dropna()
     clean_currency(data,4,14)
 
     #Parsing data


### PR DESCRIPTION
- Algumas colunas com valores NAN, conseguiam passar pela minha limpeza do dataframe, isto ocorreu apenas em fev/2019, devido á adição de uma nova linha de informações no final da planilha. 
- Uma vez que uso o comando df.dropna(), toda e qualquer linha que possua um valor NAN é removida do df , ou seja temos um resultado sem prejuízo nenhum para dados já coletados e mais seguro para a coleta de novos. 