### PR TITLE
Correção - CNJ

### DIFF
--- a/cnj/src/crawler.py
+++ b/cnj/src/crawler.py
@@ -63,7 +63,7 @@ def download(court, payroll, output_path, driver):
     download.click()
 
     # The court of SP is way bigger than the others 
-    if(court == "tjsp"):
+    if(court == "TJSP"):
         time.sleep(180)
     else: 
         time.sleep(50)


### PR DESCRIPTION
O Tribunal de Justiça de SP é consideravelmente maior que os outros órgãos. Por essa razão faz-se necessário esperar mais para q o download seja feito, antes de executar os próximos passos.